### PR TITLE
Named Routes shouldn't override existing ones (currently route recognition goes with the earliest match, named routes use the latest match)

### DIFF
--- a/lib/journey/routes.rb
+++ b/lib/journey/routes.rb
@@ -59,7 +59,7 @@ module Journey
       route = Route.new(name, app, path, conditions, defaults)
 
       routes << route
-      named_routes[name] = route if name
+      named_routes[name] = route if name && !named_routes[name]
       clear_cache!
       route
     end


### PR DESCRIPTION
In the same way that I've just had this fixed in Rails, the same issue exists in Journey (which in effect means the change in Rails has made no difference to my application and likely others).

The Rails pull request is https://github.com/rails/rails/pull/3861

I've just fixed it in Journey with this commit.

There are no failed test cases, but no new ones either (I can't understand the tests in Journey as easily as I could the Rails test cases). If you can give me a pointer to a similar test case that I can use as a template to test this, I'll happily add it to this pull request (if I can manage to write the test).
