### PR TITLE
Sort the alphabet so the order is consistent

### DIFF
--- a/lib/journey/nfa/transition_table.rb
+++ b/lib/journey/nfa/transition_table.rb
@@ -109,7 +109,7 @@ module Journey
       end
 
       def alphabet
-        inverted.values.map(&:keys).flatten.compact.uniq
+        inverted.values.map(&:keys).flatten.compact.uniq.sort_by { |x| x.to_s }
       end
 
       ###

--- a/test/nfa/test_transition_table.rb
+++ b/test/nfa/test_transition_table.rb
@@ -53,7 +53,7 @@ module Journey
 
       def test_alphabet
         table  = tt 'a|:a'
-        assert_equal ['a', /[^\.\/\?]+/], table.alphabet
+        assert_equal [/[^\.\/\?]+/, 'a'], table.alphabet
 
         table  = tt 'a|a'
         assert_equal ['a'], table.alphabet


### PR DESCRIPTION
The alphabet is generated via Hash#keys, which is unsorted. Sort it manually so that it's consistent.
