### PR TITLE
Fix optional route parts with parameters

### DIFF
--- a/lib/journey/visitors.rb
+++ b/lib/journey/visitors.rb
@@ -88,7 +88,8 @@ module Journey
         if consumed == options
           nil
         else
-          visit node.left
+          route = visit node.left
+          route.include?("\0") ? nil : route
         end
       end
 
@@ -107,8 +108,7 @@ module Journey
       def visit_SYMBOL node
         key = node.to_sym
 
-        if options.key? key
-          value = options[key]
+        if value = options[key]
           consumed[key] = value
           Router::Utils.escape_path(value)
         else

--- a/test/test_route.rb
+++ b/test/test_route.rb
@@ -74,6 +74,20 @@ module Journey
       assert_equal '/page/10', route.format({ :id => 10 })
     end
 
+    def test_extras_are_not_included_if_optional_with_parameter
+      path  = Path::Pattern.new '(/sections/:section)/pages/:id'
+      route = Route.new("name", nil, path, { }, { :action => 'show' })
+
+      assert_equal '/pages/10', route.format({:id => 10})
+    end
+
+    def test_extras_are_not_included_if_optional_parameter_is_nil
+      path  = Path::Pattern.new '(/sections/:section)/pages/:id'
+      route = Route.new("name", nil, path, { }, { :action => 'show' })
+
+      assert_equal '/pages/10', route.format({:id => 10, :section => nil})
+    end
+
     def test_score
       path = Path::Pattern.new "/page/:id(/:action)(.:format)"
       specific = Route.new "name", nil, path, {}, {:controller=>"pages", :action=>"show"}


### PR DESCRIPTION
In rails 3.1 the following route:

``` ruby
scope "(/optional/:optional_id)" do
  resources :things
end
```

Will generate a helper:

``` ruby
things_path # => "/things"
things_path(:optional_id => nil) # => "/things"
```

In rails 3.2.0.rc1 same route generates

``` ruby
things_path # => "/optional/things"
things_path(:optional_id => nil) # => "/optional//things"
```

This patch makes journey behave in the same way as 3.1
