### PR TITLE
Support encoded UTF-8 paths

### DIFF
--- a/lib/journey/scanner.rb
+++ b/lib/journey/scanner.rb
@@ -47,7 +47,7 @@ module Journey
         [:DOT, text]
       when text = @ss.scan(/:\w+/)
         [:SYMBOL, text]
-      when text = @ss.scan(/[\w-]+/)
+      when text = @ss.scan(/[\w%-]+/)
         [:LITERAL, text]
         # any char
       when text = @ss.scan(/./)

--- a/test/test_router.rb
+++ b/test/test_router.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require 'helper'
 
 module Journey
@@ -42,6 +43,24 @@ module Journey
       routes.add_route nil, path, {}, {:id => nil}, {}
 
       env = rails_env 'PATH_INFO' => '/foo-bar-baz'
+      called = false
+      router.recognize(env) do |r, _, params|
+        called = true
+      end
+      assert called
+    end
+
+    def test_unicode
+      klass  = FakeRequestFeeler.new nil
+      router = Router.new(routes, {})
+      
+      #match the escaped version of /ほげ
+      exp = Router::Strexp.new '/%E3%81%BB%E3%81%92', {}, ['/.?'] 
+      path  = Path::Pattern.new exp
+
+      routes.add_route nil, path, {}, {:id => nil}, {}
+
+      env = rails_env 'PATH_INFO' => '/%E3%81%BB%E3%81%92'
       called = false
       router.recognize(env) do |r, _, params|
         called = true


### PR DESCRIPTION
URLs can contain percent-encoded utf-8 text as per RFC 3986. Journey did
not allow of defining routes containing utf-8 text, as the scanner
improperly considered each % to a separate token.
