### PR TITLE
Fix to not allow trailing slash on script name when matching

### DIFF
--- a/lib/journey/router.rb
+++ b/lib/journey/router.rb
@@ -59,7 +59,7 @@ module Journey
                                                            @params_key)
 
         unless route.path.anchored
-          env['SCRIPT_NAME'] = script_name.to_s + match.to_s
+          env['SCRIPT_NAME'] = (script_name.to_s + match.to_s).chomp('/')
           env['PATH_INFO']   = match.post_match
         end
 

--- a/test/test_router.rb
+++ b/test/test_router.rb
@@ -51,9 +51,9 @@ module Journey
 
     def test_unicode
       router = Router.new(routes, {})
-      
+
       #match the escaped version of /ほげ
-      exp = Router::Strexp.new '/%E3%81%BB%E3%81%92', {}, ['/.?'] 
+      exp = Router::Strexp.new '/%E3%81%BB%E3%81%92', {}, ['/.?']
       path  = Path::Pattern.new exp
 
       routes.add_route nil, path, {}, {:id => nil}, {}
@@ -195,6 +195,18 @@ module Journey
       assert_equal 404, resp.first
     end
 
+    def test_clear_trailing_slash_from_script_name_on_root_unanchored_routes
+      strexp = Router::Strexp.new("/", {}, ['/', '.', '?'], false)
+      path   = Path::Pattern.new strexp
+      app    = lambda { |env| [200, {}, ['success!']] }
+      route  = @router.routes.add_route(app, path, {}, {}, {})
+
+      env  = rack_env('SCRIPT_NAME' => '', 'PATH_INFO' => '/weblog')
+      resp = @router.call(env)
+      assert_equal ['success!'], resp.last
+      assert_equal '', env['SCRIPT_NAME']
+    end
+
     def test_defaults_merge_correctly
       path  = Path::Pattern.new '/foo(/:id)'
       @router.routes.add_route nil, path, {}, {:id => nil}, {}
@@ -276,13 +288,6 @@ module Journey
 
       path, _ = @formatter.generate(:path_info, nil, { :id => 10 }, { :action => 'index' })
       assert_equal "/messages/index/10", path
-    end
-
-    def add_routes router, paths
-      paths.each do |path|
-        path  = Path::Pattern.new path
-        router.routes.add_route nil, path, {}, {}, {}
-      end
     end
 
     def test_nil_path_parts_are_ignored
@@ -498,6 +503,13 @@ module Journey
     end
 
     private
+
+    def add_routes router, paths
+      paths.each do |path|
+        path  = Path::Pattern.new path
+        router.routes.add_route nil, path, {}, {}, {}
+      end
+    end
 
     RailsEnv = Struct.new(:env)
 


### PR DESCRIPTION
This is related to a Rails issue with mounted engines on root path.
See Rails issues:

https://github.com/rails/rails/issues/2131
https://github.com/rails/rails/issues/2230
https://github.com/rails/rails/issues/2579
https://github.com/rails/rails/issues/5342

_Related_, [this issue](https://github.com/rails/rails/pull/2577) added a fix for url generation with double slashes in engines, and ended up adding by mistake the same failing test case that 5342 introduces again. The failing test case [was removed later](https://github.com/rails/rails/commit/04baa4b2cad105718ac6acda3d82b6521c4536ea), but the issue related to it still exists.

I believe this could be merged in versions for both Rails master and 3-2. Also, issue 5342 in Rails can be merged in both as well to avoid regressions, I'll add a comment there.

Let me know if something can be improved. Thanks!
