### PR TITLE
Ensure PATH_INFO will always have a leading slash

### DIFF
--- a/lib/journey/router.rb
+++ b/lib/journey/router.rb
@@ -60,7 +60,7 @@ module Journey
 
         unless route.path.anchored
           env['SCRIPT_NAME'] = (script_name.to_s + match.to_s).chomp('/')
-          env['PATH_INFO']   = match.post_match
+          env['PATH_INFO']   = Utils.normalize_path(match.post_match)
         end
 
         env[@params_key] = (set_params || {}).merge parameters

--- a/test/test_router.rb
+++ b/test/test_router.rb
@@ -207,6 +207,7 @@ module Journey
       resp = @router.call(env)
       assert_equal ['success!'], resp.last
       assert_equal '', env['SCRIPT_NAME']
+      assert_equal '/weblog', env['PATH_INFO']
     end
 
     def test_defaults_merge_correctly


### PR DESCRIPTION
Related to #24 and [this conversation in the merge commit](https://github.com/rails/journey/commit/b96ea6fb121ab63dc08c3b32c806f21dd6cb2258#commitcomment-1070210), this ensures PATH_INFO will have a leading slash.

This PR is for 1-0-stable branch, master implementation is probably going to change according to issue #17 and a similar fix is going to be part of that - without normalize_path.
