### PR TITLE
Fix test that would never fail; and make the test more intention-revealing

### DIFF
--- a/test/test_router.rb
+++ b/test/test_router.rb
@@ -257,11 +257,11 @@ module Journey
         "/messages/:id/edit(.:format)",
         "/messages/:id(.:format)"
       ]
-      env = rails_env 'PATH_INFO' => '/messages/1.1.1'
+      env = rails_env 'PATH_INFO' => '/messages/unknown/path'
       yielded = false
 
       @router.recognize(env) do |*whatever|
-        yielded = false
+        yielded = true
       end
       refute yielded
     end


### PR DESCRIPTION
Hi,

I found an issue with one of the tests.  Previously the test would never fail, so if the router recognition was broken we might not know.  I've fixed that and also changed the path under test to make it easier to see that it should not be a recognized path.

If you have any questions, please feel free to let me know.  I hope we can get this into the next Rails 3.2.x release.

Thanks!
Jeff
