### PR TITLE
Route formatter: remove unnecessary gsub call

### DIFF
--- a/lib/journey/route.rb
+++ b/lib/journey/route.rb
@@ -71,10 +71,7 @@ module Journey
         path_options.delete key if defaults[key].to_s == path_options[key].to_s
       end
 
-      formatter      = Visitors::Formatter.new(path_options)
-
-      formatted_path = formatter.accept(path.spec)
-      formatted_path.gsub(/\/\x00/, '')
+      Visitors::Formatter.new(path_options).accept(path.spec)
     end
 
     def optional_parts

--- a/test/test_route.rb
+++ b/test/test_route.rb
@@ -38,14 +38,6 @@ module Journey
       assert_equal(//, route.ip)
     end
 
-    def test_format_empty
-      path  = Path::Pattern.new '/messages/:id(.:format)'
-      route = Route.new("name", nil, path, {},
-                        { :controller => 'foo', :action => 'bar' })
-
-      assert_equal '/messages', route.format({})
-    end
-
     def test_format_with_star
       path  = Path::Pattern.new '/:controller/*extra'
       route = Route.new("name", nil, path, {},


### PR DESCRIPTION
Remove unnecessary `gsub` call.

Originally this `gsub` call appeared as "for performance" hack. But unfortunattely having it right there doesn't fix some problems described here:  https://github.com/rails/journey/commit/8317cde20b0805c30e1ff2a879a9b8ba948cfa76

Now, we can remove it.

Also removed test that asserts some internal behavior of the formatter that doesn't have a use case in actionpack: it tests behavior of formatter when it doens't have all required parameters, but this case is filtered at `verify_required_parts!`.
