### PR TITLE
Formatter#generate: optimize parameters constraints code

### DIFF
--- a/lib/journey/formatter.rb
+++ b/lib/journey/formatter.rb
@@ -30,14 +30,12 @@ module Journey
         end
 
         parameterized_parts.keep_if { |_,v| v  }
-
-        next unless verify_required_parts!(route, parameterized_parts)
-
         params = options.dup.delete_if do |key, _|
           parameterized_parts.key?(key) || route.defaults.key?(key)
         end
 
-        return [route.format(parameterized_parts), params]
+        string = route.format(parameterized_parts)
+        return [string, params] if string
       end
 
       raise Router::RoutingError
@@ -95,17 +93,6 @@ module Journey
       }.map { |pair|
         possibles(cache[pair], options, depth + 1)
       }.flatten(1)
-    end
-
-    def verify_required_parts! route, parts
-      tests = route.path.requirements
-      route.required_parts.all? { |key|
-        if tests.key? key
-          /\A#{tests[key]}\Z/ === parts[key]
-        else
-          parts.fetch(key) { false }
-        end
-      }
     end
 
     def build_cache

--- a/lib/journey/route.rb
+++ b/lib/journey/route.rb
@@ -71,7 +71,8 @@ module Journey
         value.to_s == defaults[key].to_s && !required_parts.include?(key)
       end
 
-      Visitors::Formatter.new(path_options).accept(path.spec)
+      result = Visitors::Formatter.new(path_options, path.requirements).accept(path.spec)
+      result.include?("\0") ? nil : result
     end
 
     def optional_parts

--- a/lib/journey/visitors.rb
+++ b/lib/journey/visitors.rb
@@ -78,8 +78,9 @@ module Journey
     class Formatter < Visitor
       attr_reader :options, :consumed
 
-      def initialize options
+      def initialize options, requirements
         @options  = options
+        @requirements = requirements
         @consumed = {}
       end
 
@@ -98,7 +99,7 @@ module Journey
       end
 
       def binary node
-        [visit(node.left), visit(node.right)].join
+        "#{visit(node.left)}#{visit(node.right)}"
       end
 
       def nary node
@@ -108,11 +109,13 @@ module Journey
       def visit_SYMBOL node
         key = node.to_sym
 
-        if value = options[key]
+        value = options[key]
+        return "\0" unless value
+        if requirement = @requirements[key] and !(/\A#{requirement}\Z/ === value)
+          "\0"
+        else
           consumed[key] = value
           Router::Utils.escape_path(value)
-        else
-          "\0"
         end
       end
     end

--- a/test/test_router.rb
+++ b/test/test_router.rb
@@ -172,19 +172,19 @@ module Journey
       end
     end
 
-    def test_only_required_parts_are_verified
+    def test_optional_parts_are_verified
       add_routes @router, [
         Router::Strexp.new("/foo(/:id)", {:id => /\d/}, ['/', '.', '?'], false)
       ]
 
       path, _ = @formatter.generate(:path_info, nil, { :id => '10' }, { })
-      assert_equal '/foo/10', path
+      assert_equal '/foo', path
 
       path, _ = @formatter.generate(:path_info, nil, { }, { })
       assert_equal '/foo', path
 
       path, _ = @formatter.generate(:path_info, nil, { :id => 'aa' }, { })
-      assert_equal '/foo/aa', path
+      assert_equal '/foo', path
     end
 
     def test_X_Cascade


### PR DESCRIPTION
Tried to optimize a way how router handles constraints.
During the process find out that constraints for optional parts doesn't work at all. 
They are simply ignored. This doesn't sound well. This patch changes that test to a different behavior:
Constraints for optional parts are not ignored anymore.
As @tenderlove said: journey test suite in most cases just tests journey internal and we can change behavior in case it doesn't break actionpack test suite.

Also this patch offers 10% performance boost for named routes generation.
https://gist.github.com/2915825

```
Running benchmark with current working tree
Checkout HEAD^
Running benchmark with HEAD^
Checkout to previous HEAD again

                    user     system      total        real
--------------------------------------generate without name
After patch:    0.340000   0.010000   0.350000 (  0.349404)
Before patch:   0.320000   0.030000   0.350000 (  0.356459)
Improvement: 2%

-----------------------------------------generate with name
After patch:    0.040000   0.000000   0.040000 (  0.033736)
Before patch:   0.040000   0.000000   0.040000 (  0.037829)
Improvement: 11%

-------------------------------------generate with globbing
After patch:    0.330000   0.000000   0.330000 (  0.340345)
Before patch:   0.330000   0.020000   0.350000 (  0.350696)
Improvement: 3%
```
