### PR TITLE
Add a Missing Keys Method to Formatter 

### DIFF
--- a/lib/journey/formatter.rb
+++ b/lib/journey/formatter.rb
@@ -100,6 +100,20 @@ module Journey
       routes
     end
 
+    # returns an array populated with missing keys if any are present
+    def missing_keys route, parts
+      missing_keys = []
+      tests = route.path.requirements
+      route.required_parts.each { |key|
+        if tests.key? key
+          missing_keys << key unless /\A#{tests[key]}\Z/ === parts[key]
+        else
+          missing_keys << key unless parts[key]
+        end
+      }
+      missing_keys
+    end
+
     def possibles cache, options, depth = 0
       cache.fetch(:___routes) { [] } + options.find_all { |pair|
         cache.key? pair
@@ -108,15 +122,9 @@ module Journey
       }.flatten(1)
     end
 
+    # returns boolean, true if no missing keys are present
     def verify_required_parts! route, parts
-      tests = route.path.requirements
-      route.required_parts.all? { |key|
-        if tests.key? key
-          /\A#{tests[key]}\Z/ === parts[key]
-        else
-          parts.fetch(key) { false }
-        end
-      }
+      missing_keys(route, parts).empty?
     end
 
     def build_cache

--- a/test/test_router.rb
+++ b/test/test_router.rb
@@ -187,6 +187,19 @@ module Journey
       assert_equal '/foo/aa', path
     end
 
+    def test_knows_what_parts_are_missing_from_named_route
+      route_name = "gorby_thunderhorse"
+      pattern = Router::Strexp.new("/foo/:id", { :id => /\d+/ }, ['/', '.', '?'], false)
+      path = Path::Pattern.new pattern
+      @router.routes.add_route nil, path, {}, {}, route_name
+
+      error = assert_raises(Router::RoutingError) do
+        @formatter.generate(:path_info, route_name, { }, { })
+      end
+
+      assert_match /required keys: \[:id\]/, error.message
+    end
+
     def test_X_Cascade
       add_routes @router, [ "/messages(.:format)" ]
       resp = @router.call({ 'REQUEST_METHOD' => 'GET', 'PATH_INFO' => '/lol' })


### PR DESCRIPTION
When a named route cannot be resolved due to a missing key, the router should be capable of identifying the required keys for the named route. This will be extremely useful in debugging routing errors by providing enough information to fix the problem in the message.

Once this information is available via Journey I plan to submit a PR to Rails to utilize the functionality and enhance the named route error message similar to this previous pull request: https://github.com/rails/rails/pull/6130

Functionality is tested, ATP. Let me know if you have any comments or questions.
