### PR TITLE
Don't allow failures on Rubinius

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,4 @@ rvm:
   - jruby-19mode
 matrix:
   allow_failures:
-    - rvm: rbx-19mode
     - rvm: jruby-19mode


### PR DESCRIPTION
The previous bug that caused the failure on Rubinius is now fixed.

https://github.com/rubinius/rubinius/issues/1766
