### PR TITLE
Delete old references from the manifest file

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -9,7 +9,6 @@ Rakefile
 journey.gemspec
 lib/journey.rb
 lib/journey/backwards.rb
-lib/journey/core-ext/hash.rb
 lib/journey/formatter.rb
 lib/journey/gtg/builder.rb
 lib/journey/gtg/simulator.rb


### PR DESCRIPTION
I could not build the gem until I removed the non existing file from the manifest
