### PR TITLE
add license information to the gemspec

### DIFF
--- a/journey.gemspec
+++ b/journey.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "journey"
   s.rubygems_version = "1.8.23"
   s.summary = "Journey is a router"
+  s.license = "MIT"
   s.test_files = ["test/gtg/test_builder.rb", "test/gtg/test_transition_table.rb", "test/nfa/test_simulator.rb", "test/nfa/test_transition_table.rb", "test/nodes/test_symbol.rb", "test/path/test_pattern.rb", "test/route/definition/test_parser.rb", "test/route/definition/test_scanner.rb", "test/router/test_strexp.rb", "test/router/test_utils.rb", "test/test_route.rb", "test/test_router.rb", "test/test_routes.rb"]
 
   if s.respond_to? :specification_version then


### PR DESCRIPTION
This way we can get this info when using rubygems.org api
