### PR TITLE
Add license to gemspec

### DIFF
--- a/journey.gemspec
+++ b/journey.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.rubyforge_project = "journey"
   s.rubygems_version = "1.8.23"
+  s.license = "MIT"
   s.summary = "Journey is a router"
   s.test_files = ["test/gtg/test_builder.rb", "test/gtg/test_transition_table.rb", "test/nfa/test_simulator.rb", "test/nfa/test_transition_table.rb", "test/nodes/test_symbol.rb", "test/path/test_pattern.rb", "test/route/definition/test_parser.rb", "test/route/definition/test_scanner.rb", "test/router/test_strexp.rb", "test/router/test_utils.rb", "test/test_route.rb", "test/test_router.rb", "test/test_routes.rb"]
 


### PR DESCRIPTION
Prior to this commit, the license was embedded in the source README.
This commit adds the license to the gemspec so that it will appear on
the rubygems site, making it easier for vendors to track it down.
