### PR TITLE
add missing semicolon to parser.y

### DIFF
--- a/lib/journey/parser.y
+++ b/lib/journey/parser.y
@@ -36,6 +36,7 @@ rule
     ;
   literal
     : LITERAL            { result = Literal.new(val.first) }
+    ;
   dot
     : DOT                { result = Dot.new(val.first) }
     ;


### PR DESCRIPTION
The literal production was missing a semicolon, but there was no difference in the generated parser after running `rake compile`.

This is just a small typo fix.
